### PR TITLE
fix(renovate): cover prek.toml.jinja and soft-fail render-template

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,13 @@
       "managerFilePatterns": ["/template/flake\\.nix\\.jinja$/", "/includes/flake-extra-inputs\\.jinja$/"],
       "matchStrings": ["github:(?<depName>[\\w-]+/[\\w-]+)/(?<currentDigest>[a-f0-9]+).*#\\s*(?<currentValue>v[\\S]+)"],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Git hook dependency pins in prek.toml.jinja (mirrors the native prek.toml manager, which can't parse this Jinja-templated file)",
+      "managerFilePatterns": ["/template/prek\\.toml\\.jinja$/"],
+      "matchStrings": ["repo = \"https://github\\.com/(?<depName>[\\w.-]+/[\\w.-]+)\"\\nrev = \"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "github-tags"
     }
   ]
 }

--- a/.github/workflows/render-template.yaml
+++ b/.github/workflows/render-template.yaml
@@ -23,47 +23,46 @@ jobs:
       # secrets can't be referenced directly in `if:` conditions; mirror into env first.
       RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
     steps:
-      # Skipped entirely when unconfigured (e.g. a fork with no RENOVATE_TOKEN secret).
-      # continue-on-error scoped to just this step: an invalid/expired token should
-      # soft-fail here rather than red-X the whole job, but any REAL failure in the
-      # steps below (a broken render, a bad push, etc.) must still fail loudly.
+      # Default GITHUB_TOKEN is fine here: this is a public repo and checkout only
+      # needs read access. No token gating needed on this step (or anything below,
+      # up to the push) -- they should always run so template bugs still get caught
+      # even when RENOVATE_TOKEN is unset or stale.
       - name: Checkout
-        id: checkout
-        if: ${{ env.RENOVATE_TOKEN != '' }}
-        continue-on-error: true
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.ref }}
-          token: ${{ secrets.RENOVATE_TOKEN }}
 
       - uses: ./.github/actions/nix-setup
-        if: ${{ steps.checkout.outcome == 'success' }}
 
       - name: Set up Git
-        if: ${{ steps.checkout.outcome == 'success' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Re-render from template
-        if: ${{ steps.checkout.outcome == 'success' }}
         run: nix develop -c just render
 
       - name: Update flake lock if inputs changed
-        if: ${{ steps.checkout.outcome == 'success' }}
         run: |
           if ! git diff --quiet flake.nix; then
             nix flake lock
           fi
 
       - name: Restore copier answers
-        if: ${{ steps.checkout.outcome == 'success' }}
         run: git restore .copier-answers.yaml
 
+      # The only step that actually needs a non-default token: GITHUB_TOKEN-authored
+      # pushes don't trigger downstream workflow runs (pr-checks.yaml wouldn't re-run
+      # on the pushed commit), and pushing a change to a workflow file needs
+      # `workflows: write`, which GITHUB_TOKEN doesn't have here. Skipped entirely
+      # when unconfigured (e.g. a fork); soft-fails (rather than red-X'ing the PR)
+      # when the token is set but invalid/expired.
       - name: Commit and push if changed
-        if: ${{ steps.checkout.outcome == 'success' }}
+        if: ${{ env.RENOVATE_TOKEN != '' }}
+        continue-on-error: true
         run: |
           if [ -n "$(git status --porcelain)" ]; then
+            git remote set-url origin "https://x-access-token:${RENOVATE_TOKEN}@github.com/${{ github.repository }}.git"
             git add -A
             git commit -m "chore: re-render root files from updated template"
             git push

--- a/.github/workflows/render-template.yaml
+++ b/.github/workflows/render-template.yaml
@@ -16,35 +16,50 @@ permissions:
 jobs:
   render:
     runs-on: ubuntu-latest
+    # Soft-fail: an unconfigured or stale RENOVATE_TOKEN (e.g. on a fork, or if the
+    # token expires) shouldn't red-X every Renovate PR touching includes/**|template/**.
+    continue-on-error: true
     permissions:
       contents: write
     timeout-minutes: 15
+    env:
+      # secrets can't be referenced directly in `if:` conditions; mirror into env first.
+      RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        id: checkout
+        if: ${{ env.RENOVATE_TOKEN != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.RENOVATE_TOKEN }}
 
       - uses: ./.github/actions/nix-setup
+        if: ${{ steps.checkout.outcome == 'success' }}
 
       - name: Set up Git
+        if: ${{ steps.checkout.outcome == 'success' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Re-render from template
+        if: ${{ steps.checkout.outcome == 'success' }}
         run: nix develop -c just render
 
       - name: Update flake lock if inputs changed
+        if: ${{ steps.checkout.outcome == 'success' }}
         run: |
           if ! git diff --quiet flake.nix; then
             nix flake lock
           fi
 
       - name: Restore copier answers
+        if: ${{ steps.checkout.outcome == 'success' }}
         run: git restore .copier-answers.yaml
 
       - name: Commit and push if changed
+        if: ${{ steps.checkout.outcome == 'success' }}
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git add -A

--- a/.github/workflows/render-template.yaml
+++ b/.github/workflows/render-template.yaml
@@ -19,14 +19,11 @@ jobs:
     permissions:
       contents: write
     timeout-minutes: 15
-    env:
-      # secrets can't be referenced directly in `if:` conditions; mirror into env first.
-      RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
     steps:
       # Default GITHUB_TOKEN is fine here: this is a public repo and checkout only
       # needs read access. No token gating needed on this step (or anything below,
       # up to the push) -- they should always run so template bugs still get caught
-      # even when RENOVATE_TOKEN is unset or stale.
+      # even when the bot token below is unset or invalid.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -51,18 +48,32 @@ jobs:
       - name: Restore copier answers
         run: git restore .copier-answers.yaml
 
+      # Mints a short-lived khepri-bot installation token instead of a static PAT --
+      # no manual rotation, no silent expiry. `vars` (unlike `secrets`) can be used
+      # directly in `if:`, so this cleanly no-ops on forks without KHEPRI_BOT_APP_ID
+      # configured. continue-on-error: an invalid/revoked key soft-fails here rather
+      # than red-X'ing the whole job.
+      - name: Generate bot token
+        id: bot-token
+        if: ${{ vars.KHEPRI_BOT_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.KHEPRI_BOT_APP_ID }}
+          private-key: ${{ secrets.KHEPRI_BOT_PRIVATE_KEY }}
+
       # The only step that actually needs a non-default token: GITHUB_TOKEN-authored
       # pushes don't trigger downstream workflow runs (pr-checks.yaml wouldn't re-run
       # on the pushed commit), and pushing a change to a workflow file needs
-      # `workflows: write`, which GITHUB_TOKEN doesn't have here. Skipped entirely
-      # when unconfigured (e.g. a fork); soft-fails (rather than red-X'ing the PR)
-      # when the token is set but invalid/expired.
+      # `workflows: write`, which GITHUB_TOKEN doesn't have here.
       - name: Commit and push if changed
-        if: ${{ env.RENOVATE_TOKEN != '' }}
+        if: ${{ steps.bot-token.outcome == 'success' }}
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            git remote set-url origin "https://x-access-token:${RENOVATE_TOKEN}@github.com/${{ github.repository }}.git"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
             git add -A
             git commit -m "chore: re-render root files from updated template"
             git push

--- a/.github/workflows/render-template.yaml
+++ b/.github/workflows/render-template.yaml
@@ -50,16 +50,16 @@ jobs:
 
       # Mints a short-lived khepri-bot installation token instead of a static PAT --
       # no manual rotation, no silent expiry. `vars` (unlike `secrets`) can be used
-      # directly in `if:`, so this cleanly no-ops on forks without KHEPRI_BOT_APP_ID
+      # directly in `if:`, so this cleanly no-ops on forks without KHEPRI_BOT_CLIENT_ID
       # configured. continue-on-error: an invalid/revoked key soft-fails here rather
       # than red-X'ing the whole job.
       - name: Generate bot token
         id: bot-token
-        if: ${{ vars.KHEPRI_BOT_APP_ID != '' }}
+        if: ${{ vars.KHEPRI_BOT_CLIENT_ID != '' }}
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.KHEPRI_BOT_APP_ID }}
+          client-id: ${{ vars.KHEPRI_BOT_CLIENT_ID }}
           private-key: ${{ secrets.KHEPRI_BOT_PRIVATE_KEY }}
 
       # The only step that actually needs a non-default token: GITHUB_TOKEN-authored

--- a/.github/workflows/render-template.yaml
+++ b/.github/workflows/render-template.yaml
@@ -16,9 +16,6 @@ permissions:
 jobs:
   render:
     runs-on: ubuntu-latest
-    # Soft-fail: an unconfigured or stale RENOVATE_TOKEN (e.g. on a fork, or if the
-    # token expires) shouldn't red-X every Renovate PR touching includes/**|template/**.
-    continue-on-error: true
     permissions:
       contents: write
     timeout-minutes: 15
@@ -26,9 +23,14 @@ jobs:
       # secrets can't be referenced directly in `if:` conditions; mirror into env first.
       RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
     steps:
+      # Skipped entirely when unconfigured (e.g. a fork with no RENOVATE_TOKEN secret).
+      # continue-on-error scoped to just this step: an invalid/expired token should
+      # soft-fail here rather than red-X the whole job, but any REAL failure in the
+      # steps below (a broken render, a bad push, etc.) must still fail loudly.
       - name: Checkout
         id: checkout
         if: ${{ env.RENOVATE_TOKEN != '' }}
+        continue-on-error: true
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.ref }}

--- a/includes/renovate-template.jinja
+++ b/includes/renovate-template.jinja
@@ -12,5 +12,12 @@
       "managerFilePatterns": ["/template/flake\\.nix\\.jinja$/", "/includes/flake-extra-inputs\\.jinja$/"],
       "matchStrings": ["github:(?<depName>[\\w-]+/[\\w-]+)/(?<currentDigest>[a-f0-9]+).*#\\s*(?<currentValue>v[\\S]+)"],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Git hook dependency pins in prek.toml.jinja (mirrors the native prek.toml manager, which can't parse this Jinja-templated file)",
+      "managerFilePatterns": ["/template/prek\\.toml\\.jinja$/"],
+      "matchStrings": ["repo = \"https://github\\.com/(?<depName>[\\w.-]+/[\\w.-]+)\"\\nrev = \"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "github-tags"
     }
 {% endif %}


### PR DESCRIPTION
## Summary
- Adds a customManager regex covering `rev = "..."` pins in `template/prek.toml.jinja`, which the native `prek.toml` (TOML/jsonata) manager can't parse since it's Jinja-templated; previously only the root `prek.toml` got bumped, so the `consistency` dogfooding check reverted any prek-tooling bump on re-render (blocks PR #16)
- `render-template.yaml` now soft-fails (`continue-on-error`) and skips its checkout/push steps when `RENOVATE_TOKEN` is unset or invalid, instead of red-X'ing every Renovate PR touching `includes/**`/`template/**` — the token itself has been dead since 2026-07-21 and needs separate rotation, but that shouldn't block this dependency-update pipeline in the meantime
- Verified the new customManager regex extracts all 6 pinned repos correctly, and validated both files with `actionlint` and Renovate's own config validator (pinned at the fleet's actual production version, 43.150.0)