### PR TITLE
fix(renovate): normalize SHA-pin comments to major-version-only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,14 +6,16 @@
       "description": "Update SHA-pinned actions in .jinja template files",
       "managerFilePatterns": ["/template/.*\\.ya?ml\\.jinja$/", "/includes/.*\\.jinja$/"],
       "matchStrings": ["uses:\\s+(?<depName>[\\w-]+/[\\w-]+)@(?<currentDigest>[a-f0-9]+)\\s+#\\s+(?<currentValue>v[\\S]+)"],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>v\\d+)"
     },
     {
       "customType": "regex",
       "description": "Update SHA-pinned Nix flake inputs in template files",
       "managerFilePatterns": ["/template/flake\\.nix\\.jinja$/", "/includes/flake-extra-inputs\\.jinja$/"],
       "matchStrings": ["github:(?<depName>[\\w-]+/[\\w-]+)/(?<currentDigest>[a-f0-9]+).*#\\s*(?<currentValue>v[\\S]+)"],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>v\\d+)"
     },
     {
       "customType": "regex",

--- a/includes/renovate-template.jinja
+++ b/includes/renovate-template.jinja
@@ -4,14 +4,16 @@
       "description": "Update SHA-pinned actions in .jinja template files",
       "managerFilePatterns": ["/template/.*\\.ya?ml\\.jinja$/", "/includes/.*\\.jinja$/"],
       "matchStrings": ["uses:\\s+(?<depName>[\\w-]+/[\\w-]+)@(?<currentDigest>[a-f0-9]+)\\s+#\\s+(?<currentValue>v[\\S]+)"],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>v\\d+)"
     },
     {
       "customType": "regex",
       "description": "Update SHA-pinned Nix flake inputs in template files",
       "managerFilePatterns": ["/template/flake\\.nix\\.jinja$/", "/includes/flake-extra-inputs\\.jinja$/"],
       "matchStrings": ["github:(?<depName>[\\w-]+/[\\w-]+)/(?<currentDigest>[a-f0-9]+).*#\\s*(?<currentValue>v[\\S]+)"],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>v\\d+)"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Renovate's native `github-actions` manager writes major-only version comments (e.g. `v7`) when bumping SHA-pinned actions in root workflow files, but the custom regex customManagers for the `.jinja` template sources resolved the full `github-releases` release tag (e.g. `v7.0.0`) for the same dependency — causing the `consistency` check to fail whenever a template's SHA-pin/flake-input comment diverges from its already-bumped root counterpart (seen on PR #19)
- Adds `extractVersionTemplate: "^(?<version>v\\d+)"` to both the SHA-pinned-actions and Nix-flake-input customManagers so they normalize to the same major-only granularity as the native manager going forward
- Verified: regenerated `.github/renovate.json` validates cleanly against the fleet's actual pinned Renovate version (43.150.0)